### PR TITLE
chore: use a deep instead of shallow copy of values

### DIFF
--- a/tests/values.go
+++ b/tests/values.go
@@ -369,7 +369,9 @@ func (c *Chart) Render(fn func(*CoderValues), options *chartutil.ReleaseOptions,
 	values := c.OriginalValues
 	if fn != nil {
 		values = &CoderValues{}
-		copier.Copy(values, c.OriginalValues)
+		copier.CopyWithOption(values, c.OriginalValues, copier.Option{
+			DeepCopy: true,
+		})
 
 		fn(values)
 	}


### PR DESCRIPTION
By default, copier performs a shallow copy, though this was not
documented very clearly. The consequence is that running tests in
parallel is racy.

This fixes the code to perform a deep copy (as originally intended)
so that parallel tests run correctly.