### PR TITLE
fix(helm): allow istio traffic in network policies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /build
+*.swp

--- a/templates/networkpolicies.yaml
+++ b/templates/networkpolicies.yaml
@@ -93,13 +93,16 @@ spec:
   # Allow egress to istio service mesh. This shouldn't cause any issues if
   # Istio is not in use.
   egress:
+  # Allow all traffic to Istio control plane. This may need to be adjusted
+  # based on your cluster configuration.
   - to:
     - namespaceSelector:
         matchLabels:
           app.kubernetes.io/name: istio-controlplane
-    - podSelector:
+      podSelector:
         matchLabels:
           istio: pilot
+  # Allow all outbound DNS traffic (53/UDP and TCP)
   - ports:
     - port: 53
       protocol: TCP

--- a/templates/networkpolicies.yaml
+++ b/templates/networkpolicies.yaml
@@ -43,7 +43,6 @@ spec:
       app.kubernetes.io/component: coderd
   policyTypes:
     - Ingress
-    - Egress
   # Deny all ingress traffic, except on our service ports
   ingress:
     - from: []
@@ -52,9 +51,6 @@ spec:
           port: 8080
         - protocol: TCP
           port: 8443
-  # Explicitly allow all egress traffic
-  egress:
-    - {}
 {{- end }}
 
 {{/* Policies for the built-in PostgreSQL database */}}
@@ -94,7 +90,19 @@ spec:
       ports:
         - protocol: TCP
           port: 5432
-  # Explicitly allow all egress traffic
+  # Allow egress to istio service mesh. This shouldn't cause any issues if
+  # Istio is not in use.
   egress:
-    - {}
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          app.kubernetes.io/name: istio-controlplane
+    - podSelector:
+        matchLabels:
+          istio: pilot
+  - ports:
+    - port: 53
+      protocol: TCP
+    - port: 53
+      protocol: UDP
 {{- end }}

--- a/templates/networkpolicies.yaml
+++ b/templates/networkpolicies.yaml
@@ -43,6 +43,7 @@ spec:
       app.kubernetes.io/component: coderd
   policyTypes:
     - Ingress
+    - Egress
   # Deny all ingress traffic, except on our service ports
   ingress:
     - from: []
@@ -51,6 +52,9 @@ spec:
           port: 8080
         - protocol: TCP
           port: 8443
+  # Explicitly allow all egress traffic
+  egress:
+    - {}
 {{- end }}
 
 {{/* Policies for the built-in PostgreSQL database */}}
@@ -90,6 +94,7 @@ spec:
       ports:
         - protocol: TCP
           port: 5432
-  # Deny all egress traffic
-  egress: []
+  # Explicitly allow all egress traffic
+  egress:
+    - {}
 {{- end }}

--- a/tests/network_policy_test.go
+++ b/tests/network_policy_test.go
@@ -79,8 +79,9 @@ func TestNetworkPolicyCoder(t *testing.T) {
 			require.Equal(t, test.ExpectCoderPolicy, exist, "coderd network policy")
 			if test.ExpectCoderPolicy {
 				require.Contains(t, policy.Spec.PolicyTypes, networkingv1.PolicyTypeIngress, "expected to restrict ingress")
-				require.NotContains(t, policy.Spec.PolicyTypes, networkingv1.PolicyTypeEgress, "expected all egress to be allowed")
-				require.Empty(t, policy.Spec.Egress, "expected empty egress rules")
+				for _, rule := range policy.Spec.Egress {
+					require.Empty(t, rule, "expected empty egress rule")
+				}
 				protocolTCP := corev1.ProtocolTCP
 
 				podSelector := &metav1.LabelSelector{}
@@ -117,7 +118,9 @@ func TestNetworkPolicyCoder(t *testing.T) {
 			if test.ExpectDatabasePolicy {
 				require.Contains(t, policy.Spec.PolicyTypes, networkingv1.PolicyTypeIngress, "expected to restrict ingress")
 				require.Contains(t, policy.Spec.PolicyTypes, networkingv1.PolicyTypeEgress, "expected to restrict egress")
-				require.Empty(t, policy.Spec.Egress, "expected empty egress rules")
+				for _, rule := range policy.Spec.Egress {
+					require.Empty(t, rule, "expected empty egress rule")
+				}
 				protocolTCP := corev1.ProtocolTCP
 
 				podSelector := &metav1.LabelSelector{}

--- a/tests/network_policy_test.go
+++ b/tests/network_policy_test.go
@@ -79,9 +79,7 @@ func TestNetworkPolicyCoder(t *testing.T) {
 			require.Equal(t, test.ExpectCoderPolicy, exist, "coderd network policy")
 			if test.ExpectCoderPolicy {
 				require.Contains(t, policy.Spec.PolicyTypes, networkingv1.PolicyTypeIngress, "expected to restrict ingress")
-				for _, rule := range policy.Spec.Egress {
-					require.Empty(t, rule, "expected empty egress rule")
-				}
+				require.NotContains(t, policy.Spec.PolicyTypes, networkingv1.PolicyTypeEgress, "expected to not restrict egress")
 				protocolTCP := corev1.ProtocolTCP
 
 				podSelector := &metav1.LabelSelector{}
@@ -118,9 +116,6 @@ func TestNetworkPolicyCoder(t *testing.T) {
 			if test.ExpectDatabasePolicy {
 				require.Contains(t, policy.Spec.PolicyTypes, networkingv1.PolicyTypeIngress, "expected to restrict ingress")
 				require.Contains(t, policy.Spec.PolicyTypes, networkingv1.PolicyTypeEgress, "expected to restrict egress")
-				for _, rule := range policy.Spec.Egress {
-					require.Empty(t, rule, "expected empty egress rule")
-				}
 				protocolTCP := corev1.ProtocolTCP
 
 				podSelector := &metav1.LabelSelector{}


### PR DESCRIPTION
Turns out that istio doesn't like the new network policy rules.
Instead of adding rules to specifically work with every service mesh out there, just allow all egress traffic from coderd and timescale.