### PR TITLE
chore: add note indicating trustProxyIP is deprecated

### DIFF
--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -1,7 +1,11 @@
 {{- if .Values.coderd.trustProxyIP -}}
-Deprecated: The coderd "trustProxyIP" setting is deprecated and will
-be removed in a future release. Instead, use the coderd "reverseProxy"
-settings, which provide fine-grained control over trusted headers and
-origins. For more information, see the proxy guide in our documentation:
-https://coder.com/docs/coder/latest/guides/deployments/proxy
+======================= DEPRECATION NOTICE =======================
+
+WARNING: The coderd "trustProxyIP" setting is deprecated. Instead,
+use the coderd "reverseProxy" setting to configure trusted headers
+and origins.
+
+See https://coder.com/docs/coder/latest/guides/deployments/proxy
+
+======================= DEPRECATION NOTICE =======================
 {{- end -}}

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -1,0 +1,3 @@
+{{- if .Values.coderd.trustProxyIP -}}
+Deprecated: The coderd "trustProxyIP" setting is deprecated and will be removed in a future release. Instead, use the coderd "reverseProxy" settings, which provide fine-grained control over trusted headers and origins.
+{{- end -}}

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -1,3 +1,7 @@
 {{- if .Values.coderd.trustProxyIP -}}
-Deprecated: The coderd "trustProxyIP" setting is deprecated and will be removed in a future release. Instead, use the coderd "reverseProxy" settings, which provide fine-grained control over trusted headers and origins.
+Deprecated: The coderd "trustProxyIP" setting is deprecated and will
+be removed in a future release. Instead, use the coderd "reverseProxy"
+settings, which provide fine-grained control over trusted headers and
+origins. For more information, see the proxy guide in our documentation:
+https://coder.com/docs/coder/latest/guides/deployments/proxy
 {{- end -}}

--- a/tests/values.go
+++ b/tests/values.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -415,6 +416,13 @@ func (c *Chart) Render(fn func(*CoderValues), options *chartutil.ReleaseOptions,
 	manifests, err := engine.Render(c.chart, vals)
 	if err != nil {
 		return nil, fmt.Errorf("failed to render Chart: %w", err)
+	}
+
+	// As a special case, ignore any .txt files (e.g. NOTES.txt)
+	for key := range manifests {
+		if filepath.Ext(key) == ".txt" {
+			delete(manifests, key)
+		}
 	}
 
 	objs, err := LoadObjectsFromManifests(manifests)


### PR DESCRIPTION
If trustProxyIP is set, emit a warning notifying the user that
this setting is deprecated and replaced by the reverseProxy
settings.

---

Tested this using: `$ helm install coder . --dry-run --set coderd.trustProxyIP=true`

Emits the following output:

```
NOTES:
======================= DEPRECATION NOTICE =======================

WARNING: The coderd "trustProxyIP" setting is deprecated. Instead,
use the coderd "reverseProxy" setting to configure trusted headers
and origins.

See https://coder.com/docs/coder/latest/guides/deployments/proxy

======================= DEPRECATION NOTICE =======================
```