### PR TITLE
feat: fail when using deprecated values

### DIFF
--- a/templates/legacy.tpl
+++ b/templates/legacy.tpl
@@ -1,0 +1,59 @@
+{{- if .Values.cemanager }}
+{{- fail "The 'cemanager' setting was removed in 1.27; use 'coderd' instead" }}
+{{- end }}
+
+{{- if .Values.devurls }}
+{{- fail "The 'devurls.host' setting was removed in 1.27; use 'coderd.devurlsHost' instead" }}
+{{- end }}
+
+{{- if .Values.ingress.loadBalancerIP }}
+{{- fail "The 'ingress.loadbalancerIP' setting was removed in 1.27; use 'coderd.serviceSpec.loadBalancerIP' instead" }}
+{{- end }}
+
+{{- if .Values.ingress.loadBalancerSourceRanges }}
+{{- fail "The 'ingress.loadbalancerIP' setting was removed in 1.27; use 'coderd.serviceSpec.loadBalancerSourceRanges' instead" }}
+{{- end }}
+
+{{- if hasKey .Values "ingress.service.externalTrafficPolicy" }}
+{{- fail "The 'ingress.loadbalancerIP' setting was removed in 1.27; use 'coderd.serviceSpec.externalTrafficPolicy' instead" }}
+{{- end }}
+
+{{- if .Values.ingress.tls.hostSecretName }}
+{{- fail "The 'ingress.tls.hostSecretName' setting was was removed in 1.27; use 'coderd.tls.hostSecretName' instead" }}
+{{- end }}
+
+{{- if .Values.ingress.tls.devurlsHostSecretName }}
+{{- fail "The 'ingress.tls.devurlsHostSecretName' setting was was removed in 1.27; use 'coderd.tls.devurlsHostSecretName' instead" }}
+{{- end }}
+
+{{- if .Values.storageClassName }}
+{{- fail "The 'storageClassName' setting was was removed in 1.27; use 'postgres.default.storageClassName' instead" }}
+{{- end }}
+
+{{- if .Values.timescale }}
+{{- fail "The 'timescale' setting was was removed in 1.27; use 'postgres.default' instead" }}
+{{- end }}
+
+{{- if .Values.postgres.useDefault }}
+{{- fail "The 'postgres.useDefault' setting was was removed in 1.27; use 'postgres.default.enable' instead" }}
+{{- end }}
+
+{{- if .Values.deploymentAnnotations }}
+{{- fail "The 'deploymentAnnotations' setting was was removed in 1.27; use 'services.annotations' instead" }}
+{{- end }}
+
+{{- if .Values.serviceTolerations }}
+{{- fail "The 'serviceTolerations' setting was was removed in 1.27; use 'services.tolerations' instead" }}
+{{- end }}
+
+{{- if .Values.clusterDomainSuffix }}
+{{- fail "The 'clusterDomainSuffix' setting was was removed in 1.27; use 'services.clusterDomainSuffix' instead" }}
+{{- end }}
+
+{{- if .Values.serviceType }}
+{{- fail "The 'serviceType' setting was was removed in 1.27; use 'services.type' instead" }}
+{{- end }}
+
+{{- if .Values.serviceAccount }}
+{{- fail "The 'serviceAccount' setting was was removed in 1.27; use 'coderd.builtinProviderServiceAccount' instead" }}
+{{- end }}

--- a/templates/legacy.tpl
+++ b/templates/legacy.tpl
@@ -1,59 +1,59 @@
 {{- if .Values.cemanager }}
-{{- fail "The 'cemanager' setting was removed in 1.27; use 'coderd' instead" }}
+{{- fail "The 'cemanager' setting was deprecated in 1.21 and removed in 1.27; use 'coderd' instead" }}
 {{- end }}
 
 {{- if .Values.devurls }}
-{{- fail "The 'devurls.host' setting was removed in 1.27; use 'coderd.devurlsHost' instead" }}
+{{- fail "The 'devurls.host' setting was deprecated in 1.21 and removed in 1.27; use 'coderd.devurlsHost' instead" }}
 {{- end }}
 
 {{- if .Values.ingress.loadBalancerIP }}
-{{- fail "The 'ingress.loadbalancerIP' setting was removed in 1.27; use 'coderd.serviceSpec.loadBalancerIP' instead" }}
+{{- fail "The 'ingress.loadbalancerIP' setting was deprecated in 1.21 and removed in 1.27; use 'coderd.serviceSpec.loadBalancerIP' instead" }}
 {{- end }}
 
 {{- if .Values.ingress.loadBalancerSourceRanges }}
-{{- fail "The 'ingress.loadbalancerIP' setting was removed in 1.27; use 'coderd.serviceSpec.loadBalancerSourceRanges' instead" }}
+{{- fail "The 'ingress.loadbalancerIP' setting was deprecated in 1.21 and removed in 1.27; use 'coderd.serviceSpec.loadBalancerSourceRanges' instead" }}
 {{- end }}
 
 {{- if hasKey .Values "ingress.service.externalTrafficPolicy" }}
-{{- fail "The 'ingress.loadbalancerIP' setting was removed in 1.27; use 'coderd.serviceSpec.externalTrafficPolicy' instead" }}
+{{- fail "The 'ingress.loadbalancerIP' setting was deprecated in 1.21 and removed in 1.27; use 'coderd.serviceSpec.externalTrafficPolicy' instead" }}
 {{- end }}
 
 {{- if .Values.ingress.tls.hostSecretName }}
-{{- fail "The 'ingress.tls.hostSecretName' setting was was removed in 1.27; use 'coderd.tls.hostSecretName' instead" }}
+{{- fail "The 'ingress.tls.hostSecretName' setting was deprecated in 1.21 and removed in 1.27; use 'coderd.tls.hostSecretName' instead" }}
 {{- end }}
 
 {{- if .Values.ingress.tls.devurlsHostSecretName }}
-{{- fail "The 'ingress.tls.devurlsHostSecretName' setting was was removed in 1.27; use 'coderd.tls.devurlsHostSecretName' instead" }}
+{{- fail "The 'ingress.tls.devurlsHostSecretName' setting was deprecated in 1.21 and removed in 1.27; use 'coderd.tls.devurlsHostSecretName' instead" }}
 {{- end }}
 
 {{- if .Values.storageClassName }}
-{{- fail "The 'storageClassName' setting was was removed in 1.27; use 'postgres.default.storageClassName' instead" }}
+{{- fail "The 'storageClassName' setting was deprecated in 1.21 and removed in 1.27; use 'postgres.default.storageClassName' instead" }}
 {{- end }}
 
 {{- if .Values.timescale }}
-{{- fail "The 'timescale' setting was was removed in 1.27; use 'postgres.default' instead" }}
+{{- fail "The 'timescale' setting was deprecated in 1.21 and removed in 1.27; use 'postgres.default' instead" }}
 {{- end }}
 
 {{- if .Values.postgres.useDefault }}
-{{- fail "The 'postgres.useDefault' setting was was removed in 1.27; use 'postgres.default.enable' instead" }}
+{{- fail "The 'postgres.useDefault' setting was deprecated in 1.21 and removed in 1.27; use 'postgres.default.enable' instead" }}
 {{- end }}
 
 {{- if .Values.deploymentAnnotations }}
-{{- fail "The 'deploymentAnnotations' setting was was removed in 1.27; use 'services.annotations' instead" }}
+{{- fail "The 'deploymentAnnotations' setting was deprecated in 1.21 and removed in 1.27; use 'services.annotations' instead" }}
 {{- end }}
 
 {{- if .Values.serviceTolerations }}
-{{- fail "The 'serviceTolerations' setting was was removed in 1.27; use 'services.tolerations' instead" }}
+{{- fail "The 'serviceTolerations' setting was deprecated in 1.21 and removed in 1.27; use 'services.tolerations' instead" }}
 {{- end }}
 
 {{- if .Values.clusterDomainSuffix }}
-{{- fail "The 'clusterDomainSuffix' setting was was removed in 1.27; use 'services.clusterDomainSuffix' instead" }}
+{{- fail "The 'clusterDomainSuffix' setting was deprecated in 1.21 and removed in 1.27; use 'services.clusterDomainSuffix' instead" }}
 {{- end }}
 
 {{- if .Values.serviceType }}
-{{- fail "The 'serviceType' setting was was removed in 1.27; use 'services.type' instead" }}
+{{- fail "The 'serviceType' setting was deprecated in 1.21 and removed in 1.27; use 'services.type' instead" }}
 {{- end }}
 
 {{- if .Values.serviceAccount }}
-{{- fail "The 'serviceAccount' setting was was removed in 1.27; use 'coderd.builtinProviderServiceAccount' instead" }}
+{{- fail "The 'serviceAccount' setting was deprecated in 1.21 and removed in 1.27; use 'coderd.builtinProviderServiceAccount' instead" }}
 {{- end }}


### PR DESCRIPTION
When using deprecated values, emit an error since those values no
longer have an effect.

---

Emits errors like the following

```
$ helm install coder . --dry-run --set=ingress.tls.hostSecretName="abc"
Error: INSTALLATION FAILED: execution error at (coder/templates/legacy.tpl:22:4): The 'ingress.tls.hostSecretName' setting was was removed in 1.27; use 'coderd.tls.hostSecretName' instead
```