### PR TITLE
feat: permit installation on Kubernetes >= 1.19

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -6,15 +6,16 @@ name: coder
 description: >
   Coder moves developer workspaces to your cloud and centralizes their
   creation and management.
-appVersion: 1.27.0
-version: 1.27.0
-# Coder follows the Kubernetes upstream version support policy, and the
-# latest stable release version of Coder supports the previous two minor
-# releases as well as the current release of Kubernetes at time of
-# publication.
+appVersion: 1.28.0
+version: 1.28.0
+# Coder has a hard requirement on Kubernetes 1.19, as this version
+# introduced the networking.k8s.io/v1 API for the Ingress and
+# NetworkPolicy resources.
 #
-# See: https://coder.com/docs/coder/latest/setup/kubernetes#supported-kubernetes-versions
-kubeVersion: ">= 1.21.0-0"
+# Additionally, the NOTES.txt file emits a warning if the cluster
+# version is outside our soft requirement, in accordance with our
+# official support policy.
+kubeVersion: ">= 1.19.0-0"
 home: https://coder.com
 keywords:
   - coder

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -9,3 +9,21 @@ See https://coder.com/docs/coder/latest/guides/deployments/proxy
 
 ======================= DEPRECATION NOTICE =======================
 {{- end -}}
+
+{{- if not (semverCompare ">= 1.21.0-0" .Capabilities.KubeVersion.Version) -}}
+======================= KUBERNETES SUPPORT =======================
+
+NOTICE: Coder follows the Kubernetes upstream version support
+policy, and the latest stable release version of Coder supports
+the previous two minor releases as well as the current release of
+Kubernetes at time of publication.
+
+Your Kubernetes version is: {{ .Capabilities.KubeVersion }}
+Coder {{ .Chart.AppVersion }} requires Kubernetes >= 1.21
+
+Coder cannot provide any guarantees of compatibility nor technical
+support for this version, in accordance with our support policy:
+https://coder.com/docs/coder/latest/setup/kubernetes#supported-kubernetes-versions
+
+======================= KUBERNETES SUPPORT =======================
+{{- end -}}

--- a/tests/defaults_test.go
+++ b/tests/defaults_test.go
@@ -115,14 +115,21 @@ func TestVersion(t *testing.T) {
 		// Uses real GKE version strings versions from:
 		// https://cloud.google.com/kubernetes-engine/docs/release-notes
 		{
-			Name:       "gke-outdated-1.19",
-			Version:    "1.19.13-gke.1900",
+			Name:       "gke-incompatible-1.15",
+			Version:    "1.15.11-gke.15",
 			Compatible: false,
 		},
 		{
-			Name:       "gke-outdated-1.20",
-			Version:    "1.20.12-gke.1500",
-			Compatible: false,
+			Name:    "gke-outdated-1.19",
+			Version: "1.19.13-gke.1900",
+			// Soft compatibility
+			Compatible: true,
+		},
+		{
+			Name:    "gke-outdated-1.20",
+			Version: "1.20.12-gke.1500",
+			// Soft compatibility
+			Compatible: true,
 		},
 		{
 			Name:       "gke-current-1.21",

--- a/tests/examples_test.go
+++ b/tests/examples_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"fmt"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -150,6 +151,13 @@ func TestExamples(t *testing.T) {
 
 			manifests, err := engine.Render(chart.chart, values)
 			require.NoError(t, err, "failed to render chart")
+
+			// As a special case, ignore any .txt files (e.g. NOTES.txt)
+			for key := range manifests {
+				if filepath.Ext(key) == ".txt" {
+					delete(manifests, key)
+				}
+			}
 
 			objs, err := LoadObjectsFromManifests(manifests)
 			require.NoError(t, err, "failed to convert manifests to objects")

--- a/tests/notes_test.go
+++ b/tests/notes_test.go
@@ -1,0 +1,71 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"helm.sh/helm/v3/pkg/chartutil"
+	"k8s.io/utils/pointer"
+)
+
+// TestVersions ensures that a warning appears for versions
+// that are incompatible.
+func TestVersions(t *testing.T) {
+	t.Parallel()
+
+	chart := LoadChart(t)
+
+	capab := chartutil.DefaultCapabilities.Copy()
+	capab.KubeVersion.Version = "1.19.13-gke.1900"
+	capab.KubeVersion.Major = "1"
+	capab.KubeVersion.Minor = "19"
+
+	warning := `======================= KUBERNETES SUPPORT =======================
+
+NOTICE: Coder follows the Kubernetes upstream version support
+policy, and the latest stable release version of Coder supports
+the previous two minor releases as well as the current release of
+Kubernetes at time of publication.
+
+Your Kubernetes version is: 1.19.13-gke.1900
+Coder 1.28.0 requires Kubernetes >= 1.21
+
+Coder cannot provide any guarantees of compatibility nor technical
+support for this version, in accordance with our support policy:
+https://coder.com/docs/coder/latest/setup/kubernetes#supported-kubernetes-versions
+
+======================= KUBERNETES SUPPORT =======================`
+
+	notes, err := chart.RenderNotes(nil, nil, capab)
+	require.NoError(t, err, "error rendering NOTES.txt")
+	require.Equal(t, warning, notes, "warning should match expected")
+}
+
+// TestDeprecatedTrustProxyIP checks that the chart emits a warning when
+// the deprecated coderd.trustProxyIP setting is set.
+func TestDeprecatedTrustProxyIP(t *testing.T) {
+	t.Parallel()
+
+	chart := LoadChart(t)
+
+	warning := `======================= DEPRECATION NOTICE =======================
+
+WARNING: The coderd "trustProxyIP" setting is deprecated. Instead,
+use the coderd "reverseProxy" setting to configure trusted headers
+and origins.
+
+See https://coder.com/docs/coder/latest/guides/deployments/proxy
+
+======================= DEPRECATION NOTICE =======================`
+
+	capab := chartutil.DefaultCapabilities.Copy()
+	capab.KubeVersion.Version = "1.23.1-gke.500"
+	capab.KubeVersion.Major = "1"
+	capab.KubeVersion.Minor = "23"
+
+	notes, err := chart.RenderNotes(func(cv *CoderValues) {
+		cv.Coderd.TrustProxyIP = pointer.Bool(true)
+	}, nil, capab)
+	require.NoError(t, err, "error rendering NOTES.txt")
+	require.Equal(t, warning, notes, "warning should match expected")
+}

--- a/tests/values.go
+++ b/tests/values.go
@@ -471,7 +471,7 @@ func (c *Chart) RenderNotes(fn func(*CoderValues), options *chartutil.ReleaseOpt
 		return "", fmt.Errorf("renderManifests: %w", err)
 	}
 
-	// As a special case, ignore any .txt files (e.g. NOTES.txt)
+	// Find and return the NOTES.txt file
 	for key, value := range manifests {
 		if filepath.Base(key) == "NOTES.txt" {
 			return value, nil


### PR DESCRIPTION
* Relax version constraint to allow installation on Kubernetes
  1.19 or later, with a warning message for unsupported versions
  (prior to 1.21)
* Set chart and app version to 1.28.0