### PR TITLE
fix: update ingress template TLS values

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -49,16 +49,16 @@ spec:
               name: tcp-{{ include "coder.serviceName" . }}
   {{- if .Values.ingress.tls.enable }}
   tls:
-    {{- if and .Values.ingress.host .Values.coderd.tls.hostSecretName }}
+    {{- if and .Values.ingress.host .Values.ingress.tls.hostSecretName }}
     - hosts:
       - {{ .Values.ingress.host | quote }}
-      secretName: {{ .Values.coderd.tls.hostSecretName }}
+      secretName: {{ .Values.ingress.tls.hostSecretName }}
     {{- end }}
     {{- if .Values.devurls }}
-    {{- if and .Values.devurls.host .Values.coderd.tls.devurlsHostSecretName }}
+    {{- if and .Values.devurls.host .Values.ingress.tls.devurlsHostSecretName }}
     - hosts:
       - {{ .Values.coderd.devurlsHost }}
-      secretName: {{ .Values.coderd.tls.devurlsHostSecretName }}
+      secretName: {{ .Values.ingress.tls.devurlsHostSecretName }}
     {{- end }}
     {{- end }}
   {{- end }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -49,16 +49,16 @@ spec:
               name: tcp-{{ include "coder.serviceName" . }}
   {{- if .Values.ingress.tls.enable }}
   tls:
-    {{- if and .Values.ingress.host .Values.ingress.tls.hostSecretName }}
+    {{- if and .Values.ingress.host .Values.coderd.tls.hostSecretName }}
     - hosts:
       - {{ .Values.ingress.host | quote }}
-      secretName: {{ .Values.ingress.tls.hostSecretName }}
+      secretName: {{ .Values.coderd.tls.hostSecretName }}
     {{- end }}
     {{- if .Values.devurls }}
-    {{- if and .Values.devurls.host .Values.ingress.tls.devurlsHostSecretName }}
+    {{- if and .Values.devurls.host .Values.coderd.tls.devurlsHostSecretName }}
     - hosts:
       - {{ .Values.coderd.devurlsHost }}
-      secretName: {{ .Values.ingress.tls.devurlsHostSecretName }}
+      secretName: {{ .Values.coderd.tls.devurlsHostSecretName }}
     {{- end }}
     {{- end }}
   {{- end }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -52,13 +52,13 @@ spec:
     {{- if and .Values.ingress.host .Values.coderd.tls.hostSecretName }}
     - hosts:
       - {{ .Values.ingress.host | quote }}
-      secretName: {{ .Values.coderd.tls.hostSecretName }}
+      secretName: {{ .Values.coderd.tls.hostSecretName | quote}}
     {{- end }}
     {{- if .Values.devurls }}
     {{- if and .Values.devurls.host .Values.coderd.tls.devurlsHostSecretName }}
     - hosts:
-      - {{ .Values.coderd.devurlsHost }}
-      secretName: {{ .Values.coderd.tls.devurlsHostSecretName }}
+      - {{ .Values.coderd.devurlsHost | quote }}
+      secretName: {{ .Values.coderd.tls.devurlsHostSecretName | quote }}
     {{- end }}
     {{- end }}
   {{- end }}

--- a/templates/legacy.tpl
+++ b/templates/legacy.tpl
@@ -18,14 +18,6 @@
 {{- fail "The 'ingress.loadbalancerIP' setting was deprecated in 1.21 and removed in 1.27; use 'coderd.serviceSpec.externalTrafficPolicy' instead" }}
 {{- end }}
 
-{{- if .Values.ingress.tls.hostSecretName }}
-{{- fail "The 'ingress.tls.hostSecretName' setting was deprecated in 1.21 and removed in 1.27; use 'coderd.tls.hostSecretName' instead" }}
-{{- end }}
-
-{{- if .Values.ingress.tls.devurlsHostSecretName }}
-{{- fail "The 'ingress.tls.devurlsHostSecretName' setting was deprecated in 1.21 and removed in 1.27; use 'coderd.tls.devurlsHostSecretName' instead" }}
-{{- end }}
-
 {{- if .Values.storageClassName }}
 {{- fail "The 'storageClassName' setting was deprecated in 1.21 and removed in 1.27; use 'postgres.default.storageClassName' instead" }}
 {{- end }}

--- a/templates/legacy.tpl
+++ b/templates/legacy.tpl
@@ -18,6 +18,14 @@
 {{- fail "The 'ingress.loadbalancerIP' setting was deprecated in 1.21 and removed in 1.27; use 'coderd.serviceSpec.externalTrafficPolicy' instead" }}
 {{- end }}
 
+{{- if .Values.ingress.tls.hostSecretName }}
+{{- fail "The 'ingress.tls.hostSecretName' setting was deprecated in 1.21 and removed in 1.27; use 'coderd.tls.hostSecretName' instead" }}
+{{- end }}
+
+{{- if .Values.ingress.tls.devurlsHostSecretName }}
+{{- fail "The 'ingress.tls.devurlsHostSecretName' setting was deprecated in 1.21 and removed in 1.27; use 'coderd.tls.devurlsHostSecretName' instead" }}
+{{- end }}
+
 {{- if .Values.storageClassName }}
 {{- fail "The 'storageClassName' setting was deprecated in 1.21 and removed in 1.27; use 'postgres.default.storageClassName' instead" }}
 {{- end }}


### PR DESCRIPTION
changed the ingress template to point to the coderd TLS values, resulting in deprecation of the `ingress.tls.hostSecretName` and `ingress.tls.devurlsHostSecretName` values.