### PR TITLE
chore: update LB IP docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ View [our docs](https://coder.com/docs/setup/installation) for detailed installa
 | coderd.serviceNodePorts.https | string | Sets a static 'coderd' service TLS nodePort This should usually be omitted. | `nil` |
 | coderd.serviceSpec | object | Specification to inject for the coderd service. See: https://kubernetes.io/docs/concepts/services-networking/service/ | `{"externalTrafficPolicy":"Local","loadBalancerIP":"","loadBalancerSourceRanges":[],"type":"LoadBalancer"}` |
 | coderd.serviceSpec.externalTrafficPolicy | string | Set the traffic policy for the service. See: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip | `"Local"` |
-| coderd.serviceSpec.loadBalancerIP | string | Set the external IP address of the Ingress service. | `""` |
+| coderd.serviceSpec.loadBalancerIP | string | Set the IP address of the coderd service. | `""` |
 | coderd.serviceSpec.loadBalancerSourceRanges | list | Traffic through the LoadBalancer will be restricted to the specified client IPs. This field will be ignored if the cloud provider does not support this feature. | `[]` |
 | coderd.serviceSpec.type | string | Set the type of Service. See: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types | `"LoadBalancer"` |
 | coderd.superAdmin.passwordSecret.key | string | The key of the secret that contains the super admin password. | `"password"` |

--- a/values.yaml
+++ b/values.yaml
@@ -19,8 +19,7 @@ coderd:
     # coderd.serviceSpec.externalTrafficPolicy -- Set the traffic policy for the service. See:
     # https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
     externalTrafficPolicy: Local
-    # coderd.serviceSpec.loadBalancerIP -- Set the external IP address of the
-    # Ingress service.
+    # coderd.serviceSpec.loadBalancerIP -- Set the IP address of the coderd service.
     loadBalancerIP: ""
     # coderd.serviceSpec.loadBalancerSourceRanges -- Traffic through the LoadBalancer
     # will be restricted to the specified client IPs. This field will be ignored if

--- a/values.yaml
+++ b/values.yaml
@@ -19,7 +19,7 @@ coderd:
     # coderd.serviceSpec.externalTrafficPolicy -- Set the traffic policy for the service. See:
     # https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
     externalTrafficPolicy: Local
-    # coderd.serviceSpec.loadBalancerIP -- Set the IP address of the coderd service.
+    # coderd.serviceSpec.loadBalancerIP -- Set the IP address of the coderd service. 
     loadBalancerIP: ""
     # coderd.serviceSpec.loadBalancerSourceRanges -- Traffic through the LoadBalancer
     # will be restricted to the specified client IPs. This field will be ignored if

--- a/values.yaml
+++ b/values.yaml
@@ -19,7 +19,7 @@ coderd:
     # coderd.serviceSpec.externalTrafficPolicy -- Set the traffic policy for the service. See:
     # https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
     externalTrafficPolicy: Local
-    # coderd.serviceSpec.loadBalancerIP -- Set the IP address of the coderd service. 
+    # coderd.serviceSpec.loadBalancerIP -- Set the IP address of the coderd service.
     loadBalancerIP: ""
     # coderd.serviceSpec.loadBalancerSourceRanges -- Traffic through the LoadBalancer
     # will be restricted to the specified client IPs. This field will be ignored if


### PR DESCRIPTION
simple change to the `loadBalancerIP` documentation. this value is applicable to both `Ingress` & `LoadBalancer` Service types, and can be used for both internal/external IPs.