### PR TITLE
Modify RBAC roles to be Openshift/OKD compliant

### DIFF
--- a/templates/rbac.yaml
+++ b/templates/rbac.yaml
@@ -46,12 +46,24 @@ metadata:
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
     app.kubernetes.io/component: {{ include "coder.serviceName" . }}
 rules:
-  - apiGroups: ["", "apps", "networking.k8s.io"] # "" indicates the core API group
-    resources: ["persistentvolumeclaims", "pods", "deployments", "services", "secrets", "pods/exec","pods/log", "events", "networkpolicies", "serviceaccounts"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims", "pods", "services", "secrets", "serviceaccounts", "pods/exec"]
     verbs: ["create", "get", "list", "watch", "update", "patch", "delete", "deletecollection"]
-  - apiGroups: ["metrics.k8s.io", "storage.k8s.io"]
-    resources: ["pods", "storageclasses"]
+  - apiGroups: [""]
+    resources: ["pods/log", "events"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["create", "get", "list", "watch", "update", "patch", "delete", "deletecollection"]
+  - apiGroups: ["metrics.k8s.io"]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["networkpolicies"]
+    verbs: ["create", "get", "list", "watch", "update", "patch", "delete", "deletecollection"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
When enumerating rules in a role, providing multiple apiGroups and
resources leads to invalid resource apiGroups combinations. E.g.:

 - apiGroups: ["", "apps"]
   resources: ["pods", "deployments"]
   rules: ["create"]

This allows "create" for pods and apps/deployments, but also invalid
combinations like

  apiVersion: v1
  kind: deployments

Openshift/OKD rejects adding these rules - users cannot add permissions
that they do not already have; and users of course don't have access
granted to create invalid resources like deployments.v1.

Signed-off-by: Burt Holzman <burt@fnal.gov>