### PR TITLE
fix: service account naming

### DIFF
--- a/templates/rbac.yaml
+++ b/templates/rbac.yaml
@@ -1,12 +1,12 @@
 {{- if not .Values.coderd.satellite.enable }}
 ---
-# The service account used by environments. It has no permissions and is only 
-# used to bind a pod security policy (if one is provided).
+# The service account used by workspaces. It has no permissions and is 
+# used to bind pod security policies, labels and annotations (if provided).
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   namespace: {{ .Release.Namespace | quote }} 
-  name: workspaces
+  name: environments
   annotations: {{ toYaml .Values.coderd.workspaceServiceAccount.annotations | nindent 4 }}
   labels:
     app.kubernetes.io/name: {{ .Chart.Name }}


### PR DESCRIPTION
fixes the below error, which was caused by  #255, which re-named the `environments` service account to `workspaces`

```
create workspace: get user info from image: create image pod: pods "image-" is forbidden: error looking up service account coder/environments: serviceaccount "environments" not found
```