### PR TITLE
feat: toggle verbose logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,13 +99,14 @@ View [our docs](https://coder.com/docs/setup/installation) for detailed installa
 | ingress.host | string | The hostname to proxy to the Coder installation. The cluster Ingress Controller typically uses server name indication or the HTTP Host header to route traffic. The dev URLs hostname is specified in coderd.devurlsHost. | `""` |
 | ingress.tls | object | Configures TLS settings for the Ingress. TLS certificates are specified in coderd.tls.hostSecretName and coderd.tls.devurlsHostSecretName. | `{"enable":false}` |
 | ingress.tls.enable | bool | Determines whether the Ingress handles TLS. | `false` |
-| logging | object | Configures the logging format and output of Coder. | `{"human":"/dev/stderr","json":"","splunk":{"channel":"","token":"","url":""},"stackdriver":""}` |
+| logging | object | Configures the logging format and output of Coder. | `{"human":"/dev/stderr","json":"","splunk":{"channel":"","token":"","url":""},"stackdriver":"","verbose":true}` |
 | logging.human | string | Location to send logs that are formatted for readability. Set to an empty string to disable. | `"/dev/stderr"` |
 | logging.json | string | Location to send logs that are formatted as JSON. Set to an empty string to disable. | `""` |
 | logging.splunk | object | Coder can send logs directly to Splunk in addition to file-based output. | `{"channel":"","token":"","url":""}` |
 | logging.splunk.token | string | Splunk HEC collector token. | `""` |
 | logging.splunk.url | string | Splunk HEC collector endpoint. | `""` |
 | logging.stackdriver | string | Location to send logs that are formatted for Google Stackdriver. Set to an empty string to disable. | `""` |
+| logging.verbose | bool | Toggles coderd debug logging. | `true` |
 | metrics | object | Configure various metrics to gain observability into Coder. | `{"amplitudeKey":""}` |
 | metrics.amplitudeKey | string | Enables telemetry pushing to Amplitude. Amplitude records how users interact with Coder, which is used to improve the product. No events store any personal information. Amplitude can be found here: https://amplitude.com/ Keep empty to disable. | `""` |
 | postgres.connector | string | Option for configuring database connector type. valid values are: - "postgres" -- default connector - "awsiamrds" -- uses AWS IAM account in environment to authenticate using   IAM to connect to an RDS instance. | `"postgres"` |

--- a/templates/coderd.yaml
+++ b/templates/coderd.yaml
@@ -143,7 +143,7 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
             - name: VERBOSE
-              value: "true"
+              value: {{ .Values.logging.verbose | quote }}
             {{- if .Values.coderd.satellite.enable }}
             - name: CODER_SATELLITE_PRIVATE_KEY
               valueFrom:

--- a/tests/values.go
+++ b/tests/values.go
@@ -234,6 +234,7 @@ type IngressTLSValues struct {
 
 // LoggingValues reflect values from logging.
 type LoggingValues struct {
+	Verbose     *bool                `json:"verbose" yaml:"verbose"`
 	Human       *string              `json:"human" yaml:"human"`
 	Stackdriver *string              `json:"stackdriver" yaml:"stackdriver"`
 	JSON        *string              `json:"json" yaml:"json"`

--- a/values.yaml
+++ b/values.yaml
@@ -459,6 +459,8 @@ services:
 
 # logging -- Configures the logging format and output of Coder.
 logging:
+  # logging.verbose -- Toggles coderd debug logging.
+  verbose: true
   # logging.human -- Location to send logs that are formatted for readability.
   # Set to an empty string to disable.
   human: /dev/stderr


### PR DESCRIPTION
a customer asked if we could filter out the `DEBUG` logging in `coderd`, as they're ingesting the logs into DataDog, and the frequency of which is driving up costs.

creates a `true/false` value for the `VERBOSE` environment variable in the `coderd` container.

closes [this issue](https://github.com/coder/v1/issues/12944).