### PR TITLE
fix: Add `sessionAffinity` to the coderd Service

### DIFF
--- a/templates/coderd.yaml
+++ b/templates/coderd.yaml
@@ -291,6 +291,7 @@ spec:
   {{- if .Values.coderd.serviceSpec }}
   {{- toYaml .Values.coderd.serviceSpec | nindent 2 }}
   {{- end }}
+  sessionAffinity: ClientIP
   selector:
     coder.deployment: {{ include "coder.serviceName" . }}
   ports:


### PR DESCRIPTION
This should prevent clients from being load balanced accross many coderd instances, which ideally results in fewer workspace connections.