### PR TITLE
Revert #267 as it does not play nice with AWS ELB

### DIFF
--- a/templates/coderd.yaml
+++ b/templates/coderd.yaml
@@ -291,7 +291,6 @@ spec:
   {{- if .Values.coderd.serviceSpec }}
   {{- toYaml .Values.coderd.serviceSpec | nindent 2 }}
   {{- end }}
-  sessionAffinity: ClientIP
   selector:
     coder.deployment: {{ include "coder.serviceName" . }}
   ports:


### PR DESCRIPTION
```
  Warning  SyncLoadBalancerFailed  96s (x6 over 4m11s)  service-controller  Error syncing load balancer: failed to ensure load balancer: unsupported load balancer affinity: ClientIP
```
Folks can still set it in `serviceSpec` if they need to.