### PR TITLE
refactor: generalize & slim down role permissions

### DIFF
--- a/templates/rbac.yaml
+++ b/templates/rbac.yaml
@@ -50,12 +50,24 @@ metadata:
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
     app.kubernetes.io/component: {{ include "coder.serviceName" . }}
 rules:
-  - apiGroups: ["", "apps", "networking.k8s.io"] # "" indicates the core API group
-    resources: ["persistentvolumeclaims", "pods", "deployments", "services", "secrets", "pods/exec","pods/log", "events", "networkpolicies", "serviceaccounts"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims", "pods", "services", "secrets", "serviceaccounts", "pods/exec"]
     verbs: ["create", "get", "list", "watch", "update", "patch", "delete", "deletecollection"]
-  - apiGroups: ["metrics.k8s.io", "storage.k8s.io"]
-    resources: ["pods", "storageclasses"]
+  - apiGroups: [""]
+    resources: ["pods/log", "events"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["create", "get", "list", "watch", "update", "patch", "delete", "deletecollection"]
+  - apiGroups: ["metrics.k8s.io"]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["networkpolicies"]
+    verbs: ["create", "get", "list", "watch", "update", "patch", "delete", "deletecollection"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/templates/rbac.yaml
+++ b/templates/rbac.yaml
@@ -51,8 +51,11 @@ metadata:
     app.kubernetes.io/component: {{ include "coder.serviceName" . }}
 rules:
   - apiGroups: [""]
-    resources: ["persistentvolumeclaims", "pods", "services", "secrets", "serviceaccounts", "pods/exec"]
+    resources: ["persistentvolumeclaims", "pods", "services", "secrets", "serviceaccounts"]
     verbs: ["create", "get", "list", "watch", "update", "patch", "delete", "deletecollection"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create"]
   - apiGroups: [""]
     resources: ["pods/log", "events"]
     verbs: ["get", "list", "watch"]

--- a/templates/rbac.yaml
+++ b/templates/rbac.yaml
@@ -59,9 +59,11 @@ rules:
   - apiGroups: ["apps"]
     resources: ["deployments"]
     verbs: ["create", "get", "list", "watch", "update", "patch", "delete", "deletecollection"]
+{{- if .Capabilities.APIVersions.Has "metrics.k8s.io/v1beta1" }}
   - apiGroups: ["metrics.k8s.io"]
     resources: ["pods"]
     verbs: ["get", "list", "watch"]
+{{- end }}
   - apiGroups: ["networking.k8s.io"]
     resources: ["networkpolicies"]
     verbs: ["create", "get", "list", "watch", "update", "patch", "delete", "deletecollection"]

--- a/tests/rbac_test.go
+++ b/tests/rbac_test.go
@@ -1,0 +1,59 @@
+package tests
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRBAC(t *testing.T) {
+	t.Parallel()
+
+	chart := LoadChart(t)
+
+	for _, tc := range []struct {
+		Name                                 string
+		ValuesFunc                           func(v *CoderValues)
+		AssertEnvironmentsServiceAccountFunc func(t testing.TB, spec *corev1.ServiceAccount)
+		AssertCoderServiceAccountFunc        func(t testing.TB, spec *corev1.ServiceAccount)
+		AssertRoleFunc                       func(t testing.TB, spec *rbacv1.Role)
+		AssertRoleBindingFunc                func(t testing.TB, spec *rbacv1.RoleBinding)
+	}{
+		{
+			Name: "Defaults",
+			AssertEnvironmentsServiceAccountFunc: func(t testing.TB, spec *corev1.ServiceAccount) {
+				assert.Empty(t, spec.Annotations)
+			},
+			AssertCoderServiceAccountFunc: func(t testing.TB, spec *corev1.ServiceAccount) {
+				assert.Empty(t, spec.Annotations)
+			},
+			AssertRoleFunc: func(t testing.TB, spec *rbacv1.Role) {
+				assert.NotEmpty(t, spec.Rules)
+			},
+			AssertRoleBindingFunc: func(t testing.TB, spec *rbacv1.RoleBinding) {
+				if assert.Len(t, spec.Subjects, 1) {
+					assert.Equal(t, spec.Subjects[0].Name, "coder")
+					assert.Equal(t, spec.Subjects[0].Kind, "ServiceAccount")
+				}
+				assert.Equal(t, spec.RoleRef.Name, "coder")
+				assert.Equal(t, spec.RoleRef.Kind, "Role")
+			},
+		},
+	} {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			objs := chart.MustRender(t, tc.ValuesFunc)
+			envSA := MustFindServiceAccount(t, objs, "environments")
+			coderSA := MustFindServiceAccount(t, objs, "coder")
+			role := MustFindRole(t, objs, "coder")
+			roleBinding := MustFindRoleBinding(t, objs, "coder")
+			tc.AssertEnvironmentsServiceAccountFunc(t, envSA)
+			tc.AssertCoderServiceAccountFunc(t, coderSA)
+			tc.AssertRoleFunc(t, role)
+			tc.AssertRoleBindingFunc(t, roleBinding)
+		})
+	}
+}

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -6,6 +6,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -57,6 +58,57 @@ func MustFindStatefulSet(t testing.TB, objs []runtime.Object, name string) *apps
 	}
 
 	t.Fatalf("failed to find statefulset %q, found %v", name, names)
+	return nil
+}
+
+// MustFindServiceAccount finds a service account in the given slice of objects
+// with the given name, or fails the test.
+func MustFindServiceAccount(t testing.TB, objs []runtime.Object, name string) *corev1.ServiceAccount {
+	names := []string{}
+	for _, obj := range objs {
+		if serviceAccount, ok := obj.(*corev1.ServiceAccount); ok {
+			if serviceAccount.Name == name {
+				return serviceAccount
+			}
+			names = append(names, serviceAccount.Name)
+		}
+	}
+
+	t.Fatalf("failed to find serviceaccount %q, found %v", name, names)
+	return nil
+}
+
+// MustFindRole finds a role in the given slice of objects
+// with the given name, or fails the test.
+func MustFindRole(t testing.TB, objs []runtime.Object, name string) *rbacv1.Role {
+	names := []string{}
+	for _, obj := range objs {
+		if role, ok := obj.(*rbacv1.Role); ok {
+			if role.Name == name {
+				return role
+			}
+			names = append(names, role.Name)
+		}
+	}
+
+	t.Fatalf("failed to find role %q, found %v", name, names)
+	return nil
+}
+
+// MustFindRoleBinding finds a role in the given slice of objects
+// with the given name, or fails the test.
+func MustFindRoleBinding(t testing.TB, objs []runtime.Object, name string) *rbacv1.RoleBinding {
+	names := []string{}
+	for _, obj := range objs {
+		if roleBinding, ok := obj.(*rbacv1.RoleBinding); ok {
+			if roleBinding.Name == name {
+				return roleBinding
+			}
+			names = append(names, roleBinding.Name)
+		}
+	}
+
+	t.Fatalf("failed to find rolebinding %q, found %v", name, names)
 	return nil
 }
 


### PR DESCRIPTION
this PR builds on the work done in #252 and the feedback in #269. I'm leaving this in a draft state as we work to identify & remove unnecessary permissions.

ideally this should slim down the role to only the bare minimum permissions, as to enable smoother installs on OpenShift and any K8s distro.